### PR TITLE
add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build DLL
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+    runs-on: windows-latest
+    env:
+        SolutionName: rowblonks
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Build DLL
+      run: msbuild ${{ env.SolutionName }}.sln /m /p:PlatformToolset=v143 /p:Configuration=${{ matrix.configuration }}
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.SolutionName }}-${{ matrix.configuration }}
+        path: ${{ matrix.configuration }}


### PR DESCRIPTION
this adds a build workflow with github actions so you could get build artifacts and see if upstream is passing.
 `/p:PlatformToolset=v143` is specified because detours still uses v142 and github's latest windows runners don't come with the ATL component for that.